### PR TITLE
Require child class tab in tabs

### DIFF
--- a/lib/openxml/docx/properties/tabs.rb
+++ b/lib/openxml/docx/properties/tabs.rb
@@ -1,3 +1,5 @@
+require "openxml/docx/properties/tab"
+
 module OpenXml
   module Docx
     module Properties


### PR DESCRIPTION
Ensures the child class is always loaded first.