### PR TITLE
Added supported for nested Section properties

### DIFF
--- a/lib/openxml/docx/elements/family.rb
+++ b/lib/openxml/docx/elements/family.rb
@@ -13,7 +13,7 @@ module OpenXml
         def valid_font_family(value)
           ok_values = %i(auto decorative modern roman script swiss) # From the spec section 17.18.30
           message = "Invalid font family type (#{value}). Valid options are: #{ok_values.join(", ")}."
-          raise ArgumentError, message unless ok_values.inculde? value
+          raise ArgumentError, message unless ok_values.include? value
         end
 
       end

--- a/lib/openxml/docx/elements/paragraph.rb
+++ b/lib/openxml/docx/elements/paragraph.rb
@@ -38,6 +38,7 @@ module OpenXml
         property :shading
         property :spacing
         property :tabs
+        property :section
 
         def section_properties=(section)
           raise ArgumentError, "Section properties must be an instance of OpenXml::Docx::Section" unless section.is_a?(OpenXml::Docx::Section)

--- a/lib/openxml/docx/properties/container_property.rb
+++ b/lib/openxml/docx/properties/container_property.rb
@@ -7,14 +7,14 @@ module OpenXml
 
         class << self
           def child_class(*args)
-            if args.any?
-              prop_name = args.first.to_s.split(/_/).map(&:capitalize).join # LazyCamelCase
-              child_class_obj = OpenXml::Docx::Properties.const_get prop_name
-              @child_class = OpenXml::Docx::Properties.const_get prop_name
-            end
+            @child_classes = args.map do |arg|
+              prop_name = arg.to_s.split(/_/).map(&:capitalize).join # LazyCamelCase
+              OpenXml::Docx::Properties.const_get prop_name
+            end unless args.empty?
 
-            @child_class
+            @child_classes
           end
+          alias :child_classes :child_class
         end
 
         def initialize
@@ -48,15 +48,15 @@ module OpenXml
 
         def invalid_child_message
           class_name = self.class.to_s.split(/::/).last
-          "#{class_name} must be instances of OpenXml::Docx::Properties::#{child_class}"
+          "#{class_name} must be instances of one of the following: #{child_classes}"
         end
 
         def valid_child?(child)
-          child.is_a?(child_class)
+          child_classes.any? {|child_class| child.is_a?(child_class) }
         end
 
-        def child_class
-          self.class.child_class
+        def child_classes
+          self.class.child_classes
         end
 
       end

--- a/lib/openxml/docx/properties/section.rb
+++ b/lib/openxml/docx/properties/section.rb
@@ -1,0 +1,12 @@
+require "openxml/docx/properties/column"
+
+module OpenXml
+  module Docx
+    module Properties
+      class Section < ContainerProperty
+        tag :sectPr
+        child_classes :page_size, :page_margins, :columns
+      end
+    end
+  end
+end

--- a/lib/openxml/docx/style.rb
+++ b/lib/openxml/docx/style.rb
@@ -57,13 +57,17 @@ module OpenXml
         type == :character
       end
 
+      def table_style?
+        type == :table
+      end
+
       VALID_STYLE_TYPES = %i(character paragraph table)
 
     private
 
       def install_paragraph_properties
-        @character = nil
         @table = nil
+        @character = OpenXml::Docx::Elements::Run.new
         @paragraph = OpenXml::Docx::Elements::Paragraph.new
       end
 
@@ -80,9 +84,9 @@ module OpenXml
       end
 
       def property_xml(xml)
-        return paragraph.property_xml(xml) if paragraph_style?
-        return character.property_xml(xml) if character_style?
-        table.property_xml(xml)
+        return table.property_xml(xml) if table_style?
+        character.property_xml(xml)
+        paragraph.property_xml(xml) if paragraph_style?
       end
 
       def valid_style_type(value)

--- a/spec/elements/paragraph_spec.rb
+++ b/spec/elements/paragraph_spec.rb
@@ -30,4 +30,29 @@ describe OpenXml::Docx::Elements::Paragraph do
     it_should_output_correct_xml
   end
 
+  context "with section properties" do
+    before(:each) do
+      @instance = described_class.new
+      ps = OpenXml::Docx::Properties::PageSize.new
+      ps.height = 15840
+      ps.width = 12240
+      @instance.section << ps
+
+      pm = OpenXml::Docx::Properties::PageMargins.new
+      pm.bottom = 1440
+      pm.footer = 720
+      pm.header = 720
+      pm.left = 1440
+      pm.right = 1440
+      pm.top = 1440
+
+      @instance.section << pm
+      columns = OpenXml::Docx::Properties::Columns.new
+      columns.space = 720
+      @instance.section << columns
+
+    end
+
+    it_should_output_correct_xml node_xml: "paragraph_with_section_properties"
+  end
 end

--- a/spec/support/data/elements/paragraph_with_section_properties_element.xml
+++ b/spec/support/data/elements/paragraph_with_section_properties_element.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<root xmlns:w="http://wnamespace.org">
+  <w:p>
+    <w:pPr>
+      <w:sectPr>
+        <w:pgSz w:h="15840" w:w="12240"/>
+        <w:pgMar w:bottom="1440" w:footer="720" w:header="720" w:left="1440" w:right="1440" w:top="1440"/>
+        <w:cols w:space="720"/>
+      </w:sectPr>
+    </w:pPr>
+  </w:p>
+</root>


### PR DESCRIPTION
In order to split a document into sections with different properties, you need to nest the Section  Properties inside Paragraph Properties.

This PR allows you to `<<`  `sectPr` into `pPr`. 

```ruby
paragraph = Paragraph.new
section = OpenXml::Docx::Section.new

section.page_size.height = 15840
...define more section properties

paragraph.section << section
```

Which results in
```xml
<w:p>
  <w:pPr>
    <w:keepLines/>
    <w:rPr>
      <w:rStyle w:val="a0"/>
    </w:rPr>
    <w:sectPr w:rsidR="00513F7E" w:rsidSect="00513F7E">
      <w:pgSz w:h="15840" w:w="12240"/>
      <w:pgMar w:bottom="1440" w:footer="720" w:gutter="0" w:header="720" w:left="1440" w:right="1440" w:top="1440"/>
      <w:cols w:space="720"/>
    </w:sectPr>
  </w:pPr>
</w:p>
```