### PR TITLE
Fixed typo in section.rb requires

### DIFF
--- a/lib/openxml/docx/properties/section.rb
+++ b/lib/openxml/docx/properties/section.rb
@@ -1,4 +1,4 @@
-require "openxml/docx/properties/column"
+require "openxml/docx/properties/columns"
 require "openxml/docx/properties/page_margins"
 require "openxml/docx/properties/page_size"
 require "openxml/docx/properties/header_reference"


### PR DESCRIPTION
Was including `column` when we needed to be including `columns`