### PR TITLE
Fixed omission of style properties in style tag

### DIFF
--- a/lib/openxml/docx/style.rb
+++ b/lib/openxml/docx/style.rb
@@ -84,9 +84,17 @@ module OpenXml
       end
 
       def property_xml(xml)
+        style_property_xml(xml)
+
         return table.property_xml(xml) if table_style?
         character.property_xml(xml)
         paragraph.property_xml(xml) if paragraph_style?
+      end
+
+      def style_property_xml(xml)
+        props = properties.keys.map(&method(:send)).compact
+        return if props.none?(&:render?)
+        props.each { |prop| prop.to_xml(xml) }
       end
 
       def valid_style_type(value)


### PR DESCRIPTION
Properties on a `<w:style>` tag could be set, but wouldn't be included in xml generation. :sweat: 