### PR TITLE
DSL

### DIFF
--- a/examples/dsl
+++ b/examples/dsl
@@ -1,0 +1,134 @@
+#!/usr/bin/env ruby
+
+$:.push Dir.pwd + "/lib"
+require "ox"
+require "openxml/docx"
+
+ROWS = 8
+COLUMNS = 4
+
+def build_docx
+  docx = OpenXml::Docx::Package.new
+
+  heading = OpenXml::Docx::Elements::Paragraph.new
+    .paragraph_style("Heading1")
+
+  heading << OpenXml::Docx::Elements::Run.new("A Table of Some Sort")
+  docx.document << heading
+
+  table = OpenXml::Docx::Elements::Table.new
+    .width(5000)
+    .width_unit(:pct)
+    .table_style("TableGrid")
+
+  ROWS.times do
+    row = OpenXml::Docx::Elements::TableRow.new
+
+    COLUMNS.times do
+      cell = OpenXml::Docx::Elements::TableCell.new
+
+      paragraph = OpenXml::Docx::Elements::Paragraph.new
+        .paragraph_style("CellText")
+      line_one = OpenXml::Docx::Elements::Run.new("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+      line_one << OpenXml::Docx::Elements::Break.new
+      line_two = OpenXml::Docx::Elements::Run.new("Donec a diam lectus. Sed sit amet ipsum mauris.")
+
+      paragraph << line_one
+      paragraph << line_two
+      cell << paragraph
+      row << cell
+    end
+
+    table << row
+  end
+
+  docx.document << table
+  docx.document << OpenXml::Docx::Section.new
+    .page_size
+      .height(15840)
+      .width(12240)
+      .orientation(:portrait)
+      .end_chain
+    .page_margins
+      .bottom(720)
+      .footer(360)
+      .gutter(0)
+      .header(360)
+      .left(720)
+      .right(720)
+      .top(720)
+      .end_chain
+
+  docx.styles << build_heading_style
+  docx.styles << build_table_style
+  docx.styles << build_cell_text_style
+
+  filename = "rocx_test_table.docx"
+  system "rm -f ~/Desktop/#{filename}" # -f so that we don't have an error if the file doesn't exist
+  docx.save File.expand_path("~/Desktop/#{filename}")
+  exec "open ~/Desktop/#{filename}"
+end
+
+def build_table_style
+  OpenXml::Docx::Style.new(:table)
+    .id("TableGrid")
+    .style_name("Table Grid")
+    .primary_style(true)
+    .table
+      .table_borders do
+        all_tags.each do |tag_name|
+          push OpenXml::Docx::Properties::TableBorder.new(tag_name, :single)
+            .color("000000")
+            .width(8)
+        end
+      end
+      .table_cell_margins do
+        vertical_tags.each do |tag_name|
+          push OpenXml::Docx::Properties::TableCellMargin.new(tag_name)
+            .type(:dxa)
+            .width(0)
+        end
+        horizontal_tags.each do |tag_name|
+          push OpenXml::Docx::Properties::TableCellMargin.new(tag_name)
+            .type(:dxa)
+            .width(108)
+        end
+      end
+      .end_chain
+end
+
+def build_heading_style
+  OpenXml::Docx::Style.new(:paragraph)
+    .id("Heading1")
+    .style_name("Heading 1")
+    .primary_style(true)
+    .paragraph
+      .alignment(:center)
+      .end_chain
+    .character
+      .bold(true)
+      .font_size(48)
+      .end_chain
+end
+
+def build_cell_text_style
+  OpenXml::Docx::Style.new(:paragraph)
+    .id("CellText")
+    .style_name("Table Cell")
+    .primary_style(true)
+    .paragraph
+      .alignment(:center)
+      .text_alignment(:center)
+      .end_chain
+    .character
+      .font
+        .ascii("Times New Roman")
+        .high_ansi("Times New Roman")
+        .end_chain
+      .font_size(20)
+      .end_chain
+end
+
+# Do the thing!
+build_docx
+

--- a/lib/openxml/docx/attribute_builder.rb
+++ b/lib/openxml/docx/attribute_builder.rb
@@ -204,16 +204,21 @@ module OpenXml
 
       module ClassMethods
         def attribute(name, expects: nil, one_of: nil, displays_as: nil, namespace: nil, matches: nil, deprecated: false)
-          bad_names = %w(tag name namespace properties_tag)
+          bad_names = %w(tag name namespace properties_tag class)
           raise ArgumentError if bad_names.member? name
-
-          attr_reader name
 
           define_method "#{name}=" do |value|
             valid_in?(value, one_of) unless one_of.nil?
             send(expects, value) unless expects.nil?
             matches?(value, matches) unless matches.nil?
             instance_variable_set "@#{name}", value
+          end
+
+          # Attributes will return the element, properties will return property
+          define_method "#{name}" do |*args|
+            return instance_variable_get "@#{name}" if args.empty?
+            public_send(:"#{name}=", args.first)
+            self
           end
 
           camelized_name = name.to_s.gsub(/_([a-z])/i) { $1.upcase }.to_sym

--- a/lib/openxml/docx/chainable_nested_context.rb
+++ b/lib/openxml/docx/chainable_nested_context.rb
@@ -1,0 +1,9 @@
+module OpenXml
+  module Docx
+    module ChainableNestedContext
+      def end_chain
+        @self_was
+      end
+    end
+  end
+end

--- a/lib/openxml/docx/elements/container.rb
+++ b/lib/openxml/docx/elements/container.rb
@@ -6,8 +6,9 @@ module OpenXml
 
         attr_reader :children
 
-        def initialize
+        def initialize(options={})
           @children = []
+          super
         end
 
         def <<(child)

--- a/lib/openxml/docx/elements/container.rb
+++ b/lib/openxml/docx/elements/container.rb
@@ -21,6 +21,13 @@ module OpenXml
           }
         end
 
+        def method_missing(method, *args, &block)
+          found_child = children.select { |child| child.name == method.to_s }
+          return if found_child.empty?
+          return found_child.first if found_child.count == 1
+          found_child
+        end
+
       private
 
         def properties_tag

--- a/lib/openxml/docx/elements/container.rb
+++ b/lib/openxml/docx/elements/container.rb
@@ -13,6 +13,13 @@ module OpenXml
 
         def <<(child)
           children << child
+          self
+        end
+        alias :push :<<
+
+        def concat(new_children)
+          Array(new_children).each { |child| self.push child }
+          self
         end
 
         def to_xml(xml)

--- a/lib/openxml/docx/elements/element.rb
+++ b/lib/openxml/docx/elements/element.rb
@@ -25,6 +25,21 @@ module OpenXml
 
         end
 
+        def initialize(options={})
+          options.each do |(attr_name, value)|
+            self.public_send("#{attr_name}=", value) if self.respond_to? :"#{attr_name}="
+          end
+
+          if block_given?
+            block = Proc.new
+            if block.arity == 0
+              instance_eval(&block)
+            else
+              yield self
+            end
+          end
+        end
+
         def tag
           self.class.tag || default_tag
         end

--- a/lib/openxml/docx/elements/element.rb
+++ b/lib/openxml/docx/elements/element.rb
@@ -15,7 +15,7 @@ module OpenXml
 
           def name(*args)
             @property_name = args.first if args.any?
-            @name
+            @property_name
           end
 
           def namespace(*args)

--- a/lib/openxml/docx/elements/element.rb
+++ b/lib/openxml/docx/elements/element.rb
@@ -26,6 +26,8 @@ module OpenXml
         end
 
         def initialize(options={})
+          build_scaffold if options.fetch(:scaffold, true)
+
           options.each do |(attr_name, value)|
             self.public_send("#{attr_name}=", value) if self.respond_to? :"#{attr_name}="
           end
@@ -57,6 +59,11 @@ module OpenXml
         end
 
       private
+
+        # Override in subclasses to set up default attributes, properties, and children
+        # when the `build` class method is used to construct the object
+        def build_scaffold
+        end
 
         def default_tag
           (class_name[0, 1].downcase + class_name[1..-1]).to_sym

--- a/lib/openxml/docx/elements/run.rb
+++ b/lib/openxml/docx/elements/run.rb
@@ -1,3 +1,5 @@
+require "openxml/docx/elements/text"
+
 module OpenXml
   module Docx
     module Elements
@@ -44,6 +46,12 @@ module OpenXml
         property :manual_width
         property :shading
         property :underline
+
+        def initialize(text=nil, options={})
+          # More performant than &block: http://mudge.name/2011/01/26/passing-blocks-in-ruby-without-block.html
+          block_given? ? super(options, &Proc.new) : super(options)
+          push OpenXml::Docx::Elements::Text.new(text).space(options.fetch(:text_spacing, :preserve)) unless text.nil?
+        end
 
       end
     end

--- a/lib/openxml/docx/elements/table.rb
+++ b/lib/openxml/docx/elements/table.rb
@@ -24,6 +24,19 @@ module OpenXml
         property :table_p_pr
         property :table_width
 
+        def width(*args)
+          return table_width.width if args.empty?
+          table_width.width = args.first
+          table_width.type = :dxa if table_width.type == :auto
+          self
+        end
+
+        def width_unit(*args)
+          return table_width.type if args.empty?
+          table_width.type = args.first
+          self
+        end
+
       private
 
         def build_scaffold

--- a/lib/openxml/docx/elements/table.rb
+++ b/lib/openxml/docx/elements/table.rb
@@ -24,6 +24,15 @@ module OpenXml
         property :table_p_pr
         property :table_width
 
+      private
+
+        def build_scaffold
+          table_width.type = :auto
+          table_width.width = 0
+          table_layout.type = :fixed
+          push OpenXml::Docx::Elements::TableGrid.new
+        end
+
       end
     end
   end

--- a/lib/openxml/docx/properties/base_property.rb
+++ b/lib/openxml/docx/properties/base_property.rb
@@ -20,7 +20,7 @@ module OpenXml
 
           def name(*args)
             @property_name = args.first if args.any?
-            @name
+            @property_name
           end
 
           def namespace(*args)

--- a/lib/openxml/docx/properties/base_property.rb
+++ b/lib/openxml/docx/properties/base_property.rb
@@ -29,12 +29,13 @@ module OpenXml
           end
         end
 
-        def initialize(tag=nil, *args)
+        def initialize(tag=nil, *args, scaffold: true)
           return unless self.class.allowed_tags
           unless self.class.allowed_tags.include?(tag)
             raise ArgumentError, "Invalid tag name for #{name}: #{tag.inspect}. It should be one of #{self.class.allowed_tags.join(", ")}."
           end
           @tag = tag
+          build_scaffold if scaffold
 
           if block_given?
             if block.arity == 0
@@ -74,6 +75,9 @@ module OpenXml
         end
 
       private
+
+        def build_scaffold
+        end
 
         def class_name
           self.class.to_s.split(/::/).last

--- a/lib/openxml/docx/properties/base_property.rb
+++ b/lib/openxml/docx/properties/base_property.rb
@@ -35,6 +35,14 @@ module OpenXml
             raise ArgumentError, "Invalid tag name for #{name}: #{tag.inspect}. It should be one of #{self.class.allowed_tags.join(", ")}."
           end
           @tag = tag
+
+          if block_given?
+            if block.arity == 0
+              instance_eval(&block)
+            else
+              yield self
+            end
+          end
         end
 
         def render?

--- a/lib/openxml/docx/properties/container_property.rb
+++ b/lib/openxml/docx/properties/container_property.rb
@@ -42,6 +42,13 @@ module OpenXml
           }
         end
 
+        def method_missing(method, *args, &block)
+          found_child = children.select { |child| child.name == method.to_s }
+          return if found_child.empty?
+          return found_child.first if found_child.count == 1
+          found_child
+        end
+
       private
 
         attr_reader :children

--- a/lib/openxml/docx/properties/container_property.rb
+++ b/lib/openxml/docx/properties/container_property.rb
@@ -17,8 +17,9 @@ module OpenXml
           alias :child_classes :child_class
         end
 
-        def initialize
+        def initialize(*args)
           @children = []
+          super
         end
 
         def <<(child)

--- a/lib/openxml/docx/properties/container_property.rb
+++ b/lib/openxml/docx/properties/container_property.rb
@@ -25,6 +25,13 @@ module OpenXml
         def <<(child)
           raise ArgumentError, invalid_child_message unless valid_child?(child)
           children << child
+          self
+        end
+        alias :push :<<
+
+        def concat(new_children)
+          Array(new_children).each { |child| self.push child }
+          self
         end
 
         def each(*args, &block)

--- a/lib/openxml/docx/properties/table_borders.rb
+++ b/lib/openxml/docx/properties/table_borders.rb
@@ -7,6 +7,18 @@ module OpenXml
         tag :tblBorders
         child_class :table_border
 
+        def vertical_tags
+          %i(left right insideV)
+        end
+
+        def horizontal_tags
+          %i(top bottom insideH)
+        end
+
+        def all_tags
+          vertical_tags + horizontal_tags
+        end
+
       end
     end
   end

--- a/lib/openxml/docx/properties/table_cell_margins.rb
+++ b/lib/openxml/docx/properties/table_cell_margins.rb
@@ -7,6 +7,18 @@ module OpenXml
         tag :tblCellMar
         child_class :table_cell_margin
 
+        def vertical_tags
+          %i(top bottom)
+        end
+
+        def horizontal_tags
+          %i(left right)
+        end
+
+        def all_tags
+          vertical_tags + horizontal_tags
+        end
+
       end
     end
   end

--- a/lib/openxml/docx/style.rb
+++ b/lib/openxml/docx/style.rb
@@ -1,10 +1,12 @@
+require "openxml/docx/chainable_nested_context"
+
 module OpenXml
   module Docx
     class Style
       include AttributeBuilder
       include PropertyBuilder
 
-      attr_reader :paragraph, :character, :table, :type
+      attr_reader :type
 
       attribute :custom, expects: :boolean, displays_as: :customStyle, namespace: :w
       attribute :default, expects: :boolean, namespace: :w
@@ -33,6 +35,21 @@ module OpenXml
       def type=(value)
         @type = value
         send "install_#{value}_properties"
+      end
+
+      def paragraph
+        @paragraph.instance_variable_set "@self_was", self
+        @paragraph
+      end
+
+      def character
+        @character.instance_variable_set "@self_was", self
+        @character
+      end
+
+      def table
+        @table.instance_variable_set "@self_was", self
+        @table
       end
 
       def tag
@@ -69,18 +86,22 @@ module OpenXml
         @table = nil
         @character = OpenXml::Docx::Elements::Run.new
         @paragraph = OpenXml::Docx::Elements::Paragraph.new
+        @character.extend OpenXml::Docx::ChainableNestedContext
+        @paragraph.extend OpenXml::Docx::ChainableNestedContext
       end
 
       def install_character_properties
         @paragraph = nil
         @table = nil
         @character = OpenXml::Docx::Elements::Run.new
+        @character.extend OpenXml::Docx::ChainableNestedContext
       end
 
       def install_table_properties
         @character = nil
         @paragraph = nil
         @table = OpenXml::Docx::Elements::Table.new
+        @table.extend OpenXml::Docx::ChainableNestedContext
       end
 
       def property_xml(xml)


### PR DESCRIPTION
Enables jQuery-style method chaining, as well as element/property initialization with blocks:

```ruby
document.styles << OpenXml::Docx::Style.new(:paragraph)
  .id("ParaStyle1")
  .paragraph
    .alignment(:center)
    .end_chain
  .character
    .bold(true)
    .end_chain
...
paragraph = OpenXml::Docx::Elements::Paragraph.new
  .paragraph_style("ParaStyle1")
paragraph << OpenXml::Docx::Elements::Run.new("Text for a default text element") do
  push OpenXml::Docx::Elements::Break.new
end
```