### PR TITLE
Title Page Element

### DIFF
--- a/lib/openxml/docx/elements/title_page.rb
+++ b/lib/openxml/docx/elements/title_page.rb
@@ -1,0 +1,12 @@
+module OpenXml
+  module Docx
+    module Elements
+      class TitlePage < Element
+        tag :titlePg
+
+        attribute :value, expects: :boolean, displays_as: :val, namespace: :w
+
+      end
+    end
+  end
+end

--- a/lib/openxml/docx/properties/even_and_odd_headers.rb
+++ b/lib/openxml/docx/properties/even_and_odd_headers.rb
@@ -1,0 +1,8 @@
+module OpenXml
+  module Docx
+    module Properties
+      class EvenAndOddHeaders < ToggleProperty
+      end
+    end
+  end
+end

--- a/lib/openxml/docx/properties/title_page.rb
+++ b/lib/openxml/docx/properties/title_page.rb
@@ -1,0 +1,9 @@
+module OpenXml
+  module Docx
+    module Properties
+      class TitlePage < ToggleProperty
+        tag :titlePg
+      end
+    end
+  end
+end

--- a/lib/openxml/docx/section.rb
+++ b/lib/openxml/docx/section.rb
@@ -24,6 +24,8 @@ module OpenXml
       value_property :text_direction
       value_property :type, as: :section_type
       value_property :vertical_alignment, as: :vertical_text_alignment
+      value_property :title_page
+      value_property :even_and_odd_headers
 
       def to_xml(xml)
         property_xml xml

--- a/spec/elements/even_and_odd_headers_spec.rb
+++ b/spec/elements/even_and_odd_headers_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe OpenXml::Docx::Elements::EvenAndOddHeaders do
+  include ElementTestMacros
+
+  it_should_use tag: :evenAndOddHeaders, name: "even_and_odd_headers"
+
+  with_no_attributes_set do
+    it_should_output "<w:evenAndOddHeaders/>", assign: false
+  end
+
+  for_attribute(:value) do
+    with_value(true) do
+      it_should_assign_successfully
+      it_should_output "<w:evenAndOddHeaders w:val=\"true\"/>"
+    end
+
+    with_value(:somethingElse) do
+      it_should_raise_an_exception
+    end
+  end
+
+end

--- a/spec/elements/title_page_spec.rb
+++ b/spec/elements/title_page_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe OpenXml::Docx::Elements::TitlePage do
+  include ElementTestMacros
+
+  it_should_use tag: :titlePg, name: "title_page"
+
+  with_no_attributes_set do
+    it_should_output "<w:titlePg/>", assign: false
+  end
+
+  for_attribute(:value) do
+    with_value(true) do
+      it_should_assign_successfully
+      it_should_output "<w:titlePg w:val=\"true\"/>"
+    end
+
+    with_value(:somethingElse) do
+      it_should_raise_an_exception
+    end
+  end
+
+end

--- a/spec/properties/even_and_odd_headers_spec.rb
+++ b/spec/properties/even_and_odd_headers_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe OpenXml::Docx::Properties::EvenAndOddHeaders do
+  include ValuePropertyTestMacros
+
+  it_should_use tag: :evenAndOddHeaders, name: "even_and_odd_headers"
+
+  with_value(true) do
+    it_should_work
+    it_should_output "<w:evenAndOddHeaders/>"
+  end
+
+  with_value(false) do
+    it_should_work
+    it_should_output ""
+  end
+
+  with_value(nil) do
+    it_should_work
+    it_should_output ""
+  end
+
+end

--- a/spec/properties/title_page_spec.rb
+++ b/spec/properties/title_page_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe OpenXml::Docx::Properties::TitlePage do
+  include ValuePropertyTestMacros
+
+  it_should_use tag: :titlePg, name: "title_page"
+
+  with_value(true) do
+    it_should_work
+    it_should_output "<w:titlePg/>"
+  end
+
+  with_value(false) do
+    it_should_work
+    it_should_output ""
+  end
+
+  with_value(nil) do
+    it_should_work
+    it_should_output ""
+  end
+
+end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -20,6 +20,8 @@ describe OpenXml::Docx::Section do
   it_should_have_value_property :text_direction, with_value: :lr
   it_should_have_value_property :type, as_instance_of: :section_type, with_value: :oddPage
   it_should_have_value_property :vertical_alignment, as_instance_of: :vertical_text_alignment, with_value: :both
+  it_should_have_value_property :title_page
+  it_should_have_value_property :even_and_odd_headers
 
   context "if no attribute are set" do
     before(:each) do


### PR DESCRIPTION
Allows you to use `<w:titlePg/>` in settings, which indicates the header/footer for the first page of a section will be different.

The above works in Word, but apparently not in Pages. The preferred method, it would seem, would be to include these settings (`titlePg` and `evenAndOddHeaders`) as properties in the section properties. The PR has been updated to allow for this, as well.