### PR TITLE
Added legacy tab types as valid options for the tab property

### DIFF
--- a/lib/openxml/docx/properties/tab.rb
+++ b/lib/openxml/docx/properties/tab.rb
@@ -4,7 +4,7 @@ module OpenXml
       class Tab < BaseProperty
         attr_reader :position, :type, :leader
 
-        VALID_TYPES = %i(bar center clear decimal end num start)
+        VALID_TYPES = %i(bar center clear decimal end num start left right)
         VALID_LEADERS = [nil, :dot, :heavy, :hyphen, :middleDot, :none, :underscore]
 
         def initialize(position, type, leader=nil)


### PR DESCRIPTION
This allows us to make tabs that can be read by Word 2007