### PR TITLE
Stopped pinning ox to 2.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,17 @@ PATH
       nokogiri
       openxml-drawingml
       openxml-package (>= 0.2.2)
-      ox (~> 2.9.0)
+      ox (~> 2.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    docile (1.3.1)
-    json (2.1.0)
-    method_source (0.9.2)
+    docile (1.3.2)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.0)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     openxml-drawingml (0.2.0)
       nokogiri
@@ -25,31 +24,30 @@ GEM
       nokogiri
       ox
       rubyzip (~> 1.2.2)
-    ox (2.9.4)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rake (12.3.2)
+    ox (2.13.2)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.1)
     rr (1.2.1)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    rubyzip (1.2.2)
-    simplecov (0.16.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (1.2.4)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     timecop (0.9.1)
 
 PLATFORMS
@@ -65,4 +63,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/openxml-docx.gemspec
+++ b/openxml-docx.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "openxml-package", ">= 0.2.2"
   spec.add_dependency "openxml-drawingml"
-  spec.add_dependency "ox", "~> 2.9.0"
+  spec.add_dependency "ox", "~> 2.9"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The commit that pinned this (89fe70f685acd19c4e9bcff13fd3501aa9811e0b) meant to require Ox to be _at least_ 2.9 but didn't need to require that Ox be capped at that minor version